### PR TITLE
A-Stop Caused Gyro Reset To Fail

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -92,7 +92,11 @@ public class Robot extends LoggedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void autonomousExit() {}
+  public void autonomousExit() {
+    if (m_autonomousCommand != null) {
+      m_autonomousCommand.cancel();
+    } // Somehow this makes it so that when A-Stop is hit it doesnt run during teleop :shrug:
+  }
 
   @Override
   public void teleopInit() {


### PR DESCRIPTION
During a match, we observed that when we hit the a-stop during autonomous, the robot stopped. However, when Teleoperated began, we were unable to reset the gyro. When we spoke to a CSA, they showed us that the code was missing the functions for "AutonomousExit" that when the robot leaves autonomous, it will stop any autonomous commands. After this, we redeployed our code and sent our robot out for another match, this time intentionally hitting the a-stop. After Autonomous ended, we were able to reset the gyro and play the game as normal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the robot’s mode transition by automatically canceling any active autonomous operations when exiting autonomous mode, enhancing overall system safety and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->